### PR TITLE
Annotate classes with PortalTransactionBuilderDsl

### DIFF
--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalBackstack.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalBackstack.kt
@@ -20,7 +20,7 @@ public interface ReadOnlyBackstack<KeyT> {
 public interface PortalBackstack<KeyT> : ReadOnlyBackstack<KeyT> {
   public fun push(
     backstackEntryId: String,
-    @PortalTransactionBuilderDsl builder: PushBuilder<KeyT>.() -> Unit
+    builder: PushBuilder<KeyT>.() -> Unit
   )
 
   public fun pop(
@@ -36,6 +36,7 @@ public interface PortalBackstack<KeyT> : ReadOnlyBackstack<KeyT> {
     exitTransitionOverride: ((KeyT) -> ExitTransitionOverride?)? = null
   ): Boolean
 
+  @PortalTransactionBuilderDsl
   public interface PushBuilder<KeyT> {
     public fun add(
       portal: KeyedPortal<out KeyT>,

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalManager.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalManager.kt
@@ -17,8 +17,9 @@ public interface PortalManagerQueries<KeyT> {
   public operator fun contains(key: KeyT): Boolean
 }
 
+@Target(AnnotationTarget.CLASS)
 @DslMarker
-internal annotation class PortalTransactionBuilderDsl
+public annotation class PortalTransactionBuilderDsl
 
 public abstract class PortalManager<KeyT>(
   private val defaultErrorHandler: ((Throwable) -> Unit)? = null,
@@ -62,7 +63,7 @@ public abstract class PortalManager<KeyT>(
 
   public fun withTransaction(
     errorHandler: ((Throwable) -> Unit)? = defaultErrorHandler,
-    @PortalTransactionBuilderDsl builder: EntryBuilder<KeyT>.() -> Unit
+    builder: EntryBuilder<KeyT>.() -> Unit
   ) {
     lock.withLock {
       val isRootTransaction = portalState.startTransaction(_backstack)
@@ -105,6 +106,7 @@ public abstract class PortalManager<KeyT>(
 
   public val backstack: ReadOnlyBackstack<KeyT> = _backstack
 
+  @PortalTransactionBuilderDsl
   public interface EntryBuilder<KeyT> : PortalManagerQueries<KeyT> {
     public val backstack: PortalBackstack<KeyT>
 

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalEntryBuilder.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalEntryBuilder.kt
@@ -12,7 +12,6 @@ import com.eygraber.portal.PortalManager
 import com.eygraber.portal.PortalManagerValidation
 import com.eygraber.portal.PortalRemovedListener
 import com.eygraber.portal.PortalRendererState
-import com.eygraber.portal.PortalTransactionBuilderDsl
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 
@@ -191,7 +190,6 @@ internal class PortalEntryBuilder<KeyT>(
   @Suppress("unused")
   internal inline fun <R> PortalBackstack<KeyT>.usingBackstack(
     backstackState: PortalBackstackState,
-    @PortalTransactionBuilderDsl
     builder: PortalEntryBuilder<KeyT>.(
       MutableList<PortalBackstackEntry<KeyT>>
     ) -> R


### PR DESCRIPTION
  - This way we don't need to annotate every usage of it