### PR TITLE
Add repos for Renovate to use

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,16 @@
   ],
   "enabledManagers": ["gradle", "gradle-wrapper", "github-actions"],
   "labels": ["dependencies"],
-  "prHourlyLimit": 3
+  "prHourlyLimit": 3,
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      "depType": "dependencies",
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2/",
+        "https://dl.google.com/dl/android/maven2/",
+        "https://plugins.gradle.org/m2"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
  - Because we're configuring our repos with a convention plugin, Renovate can't find them
  - https://github.com/renovatebot/renovate/discussions/21508#discussioncomment-5614375