### PR TITLE
Separate disappearing entries from regular entries

### DIFF
--- a/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalEntry.kt
+++ b/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalEntry.kt
@@ -16,7 +16,7 @@ internal data class ComposePortalEntry<KeyT>(
   val rendererState: PortalRendererState,
   val enterTransitionOverride: EnterTransition?,
   val exitTransitionOverride: ExitTransition?,
-  val uid: Int
+  val uid: PortalEntry.Id
 ) {
   val key: KeyT = portal.key
 

--- a/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalEntry.kt
+++ b/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalEntry.kt
@@ -21,10 +21,13 @@ internal data class ComposePortalEntry<KeyT>(
   val key: KeyT = portal.key
 
   companion object {
-    fun <KeyT> fromPortalEntry(entry: PortalEntry<KeyT>) = ComposePortalEntry(
+    fun <KeyT> fromPortalEntry(
+      entry: PortalEntry<KeyT>,
+      isDisappearing: Boolean
+    ) = ComposePortalEntry(
       portal = entry.portal as? ComposePortal ?: error("portal must be a ComposePortal"),
       wasContentPreviouslyVisible = entry.wasContentPreviouslyVisible,
-      isDisappearing = entry.isDisappearing,
+      isDisappearing = isDisappearing,
       backstackState = entry.backstackState,
       rendererState = entry.rendererState,
       enterTransitionOverride = entry.enterTransitionOverride?.toComposeTransition(),

--- a/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalManager.kt
+++ b/portal-compose/src/commonMain/kotlin/com/eygraber/portal/compose/ComposePortalManager.kt
@@ -127,7 +127,7 @@ public class ComposePortalManager<KeyT>(
         DisposableEffect(Unit) {
           onDispose {
             withTransaction {
-              makeEntryDisappear(entry.key, entry.uid)
+              makeEntryDisappear(entry.uid)
             }
           }
         }
@@ -150,7 +150,7 @@ public class ComposePortalManager<KeyT>(
       DisposableEffect(Unit) {
         onDispose {
           withTransaction {
-            makeEntryDisappear(entry.key, entry.uid)
+            makeEntryDisappear(entry.uid)
           }
         }
       }

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/DisappearingPortalEntry.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/DisappearingPortalEntry.kt
@@ -1,0 +1,6 @@
+package com.eygraber.portal
+
+public data class DisappearingPortalEntry<KeyT>(
+  val entry: PortalEntry<KeyT>,
+  val index: Int
+)

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalBackstack.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalBackstack.kt
@@ -199,10 +199,6 @@ private fun <KeyT> PortalEntryBuilder<KeyT>.applyBackstackMutations(
         key = mutation.key,
         transitionOverride = exitTransitionOverride?.invoke(mutation.key)
       )
-
-      is PortalBackstackMutation.Disappearing -> disappear(
-        key = mutation.key
-      )
     }
   }
 }

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalEntry.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalEntry.kt
@@ -3,7 +3,6 @@ package com.eygraber.portal
 public data class PortalEntry<KeyT>(
   public val portal: KeyedPortal<out KeyT>,
   public val wasContentPreviouslyVisible: Boolean,
-  public val isDisappearing: Boolean,
   public val backstackState: PortalBackstackState,
   public val rendererState: PortalRendererState,
   public val enterTransitionOverride: EnterTransitionOverride?,
@@ -15,8 +14,7 @@ public data class PortalEntry<KeyT>(
   override fun toString(): String =
     """$name(
       |  key=$key,
-      |  wasContentPreviouslyVisible=$wasContentPreviouslyVisible
-      |  isDisappearing=$isDisappearing
+      |  wasContentPreviouslyVisible=$wasContentPreviouslyVisible,
       |  backstackState=$backstackState,
       |  rendererState=$rendererState,
       |  enterTransitionOverride=$enterTransitionOverride,

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalEntry.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalEntry.kt
@@ -1,5 +1,7 @@
 package com.eygraber.portal
 
+import kotlin.jvm.JvmInline
+
 public data class PortalEntry<KeyT>(
   public val portal: KeyedPortal<out KeyT>,
   public val wasContentPreviouslyVisible: Boolean,
@@ -7,9 +9,12 @@ public data class PortalEntry<KeyT>(
   public val rendererState: PortalRendererState,
   public val enterTransitionOverride: EnterTransitionOverride?,
   public val exitTransitionOverride: ExitTransitionOverride?,
-  public val uid: Int
+  public val uid: Id
 ) {
   public val key: KeyT = portal.key
+
+  @JvmInline
+  public value class Id(public val id: Int)
 
   override fun toString(): String =
     """$name(

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/PortalManager.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/PortalManager.kt
@@ -16,6 +16,7 @@ public interface PortalManagerQueries<KeyT> {
   public val portalEntries: List<PortalEntry<KeyT>>
 
   public operator fun contains(key: KeyT): Boolean
+  public operator fun contains(uid: PortalEntry.Id): Boolean
 }
 
 @Target(AnnotationTarget.CLASS)
@@ -35,6 +36,11 @@ public abstract class PortalManager<KeyT>(
   override operator fun contains(key: KeyT): Boolean =
     portalState.portalEntries.findLast { entry ->
       entry.key == key
+    } != null
+
+  override operator fun contains(uid: PortalEntry.Id): Boolean =
+    portalState.portalEntries.findLast { entry ->
+      entry.uid == uid
     } != null
 
   public fun saveState(
@@ -86,9 +92,9 @@ public abstract class PortalManager<KeyT>(
     }
   }
 
-  protected fun makeEntryDisappear(key: KeyT, uid: Int) {
+  protected fun makeEntryDisappear(uid: PortalEntry.Id) {
     portalState.transact {
-      disappear(key, uid)
+      disappear(uid)
     }
   }
 
@@ -127,13 +133,28 @@ public abstract class PortalManager<KeyT>(
       transitionOverride: EnterTransitionOverride? = null
     )
 
+    public fun attachToComposition(
+      uid: PortalEntry.Id,
+      transitionOverride: EnterTransitionOverride? = null
+    )
+
     public fun detachFromComposition(
       key: KeyT,
       transitionOverride: ExitTransitionOverride? = null
     )
 
+    public fun detachFromComposition(
+      uid: PortalEntry.Id,
+      transitionOverride: ExitTransitionOverride? = null
+    )
+
     public fun remove(
       key: KeyT,
+      transitionOverride: ExitTransitionOverride? = null
+    )
+
+    public fun remove(
+      uid: PortalEntry.Id,
       transitionOverride: ExitTransitionOverride? = null
     )
 

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalBackstackMutation.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalBackstackMutation.kt
@@ -14,8 +14,4 @@ public sealed class PortalBackstackMutation<KeyT> {
   public data class Detach<KeyT>(
     override val key: KeyT
   ) : PortalBackstackMutation<KeyT>()
-
-  public data class Disappearing<KeyT>(
-    override val key: KeyT
-  ) : PortalBackstackMutation<KeyT>()
 }

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerDeserializer.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerDeserializer.kt
@@ -51,11 +51,6 @@ private fun <KeyT> JsonArray.deserializeToPortalEntries(
     ) {
       "A serialized PortalEntry needs a \"wasContentPreviouslyVisible\" field"
     }.toBoolean(),
-    isDisappearing = requireNotNull(
-      jsonEntry["isDisappearing"]?.jsonPrimitive?.contentOrNull
-    ) {
-      "A serialized PortalEntry needs a \"isDisappearing\" field"
-    }.toBoolean(),
     backstackState = requireNotNull(
       jsonEntry["backstackState"]?.jsonPrimitive?.contentOrNull
     ) {
@@ -120,10 +115,6 @@ private fun <KeyT> JsonArray.deserializeToBackstackMutations(
     )
 
     "detach" -> PortalBackstackMutation.Detach(
-      key = key
-    )
-
-    "disappearing" -> PortalBackstackMutation.Disappearing(
       key = key
     )
 

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerDeserializer.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerDeserializer.kt
@@ -64,7 +64,7 @@ private fun <KeyT> JsonArray.deserializeToPortalEntries(
     enterTransitionOverride = null,
     exitTransitionOverride = null,
     uid = requireNotNull(
-      jsonEntry["uid"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+      jsonEntry["uid"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()?.let { PortalEntry.Id(it) }
     ) {
       "A serialized PortalEntry needs a \"uid\" field"
     }

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerSerializer.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerSerializer.kt
@@ -28,7 +28,7 @@ private fun <KeyT> List<PortalEntry<KeyT>>.serializeEntries(
         put("isAttached", entry.rendererState.isAddedOrAttached)
         put("backstackState", entry.backstackState.name)
         put("rendererState", entry.rendererState.name)
-        put("uid", entry.uid)
+        put("uid", entry.uid.id)
       }
     )
   }

--- a/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerSerializer.kt
+++ b/portal/src/commonMain/kotlin/com/eygraber/portal/internal/PortalManagerSerializer.kt
@@ -26,7 +26,6 @@ private fun <KeyT> List<PortalEntry<KeyT>>.serializeEntries(
         put("key", keySerializer(entry.key))
         put("wasContentPreviouslyVisible", entry.wasContentPreviouslyVisible)
         put("isAttached", entry.rendererState.isAddedOrAttached)
-        put("isDisappearing", entry.isDisappearing)
         put("backstackState", entry.backstackState.name)
         put("rendererState", entry.rendererState.name)
         put("uid", entry.uid)
@@ -61,8 +60,6 @@ private fun <KeyT> List<PortalBackstackMutation<KeyT>>.serializeBackstackMutatio
         is PortalBackstackMutation.Attach -> put("type", "attach")
 
         is PortalBackstackMutation.Detach -> put("type", "detach")
-
-        is PortalBackstackMutation.Disappearing -> put("type", "disappearing")
       }
     }
   }


### PR DESCRIPTION
  - There were too many issues related to regular and disappearing entries with the same key
  - It's more 'safe' to keep them separate instead of remembering to differentiate between them