### PR TITLE
Remove gradle-home-cache-includes

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -105,10 +105,6 @@ jobs:
         with:
           gradle-version: wrapper
           gradle-home-cache-cleanup: true
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
 
       - name: Run checks
         run: ./gradlew lintRelease
@@ -130,10 +126,6 @@ jobs:
         with:
           gradle-version: wrapper
           gradle-home-cache-cleanup: true
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
 
       - name: Run checks
         run: ./gradlew testRelease


### PR DESCRIPTION
  - Gradle engineer mentioned that it's best to just use the defaults unless specifically needed
  - https://gradle-community.slack.com/archives/CAHSN3LDN/p1704838374312409?thread_ts=1704653548.328589&cid=CAHSN3LDN