### PR TITLE
Fix shrinkOut ExitTransition in tests

### DIFF
--- a/samples/simple-portal/android-app/src/test/kotlin/com/eygraber/portal/samples/simpleportal/android/SimplePortalAndroidTest.kt
+++ b/samples/simple-portal/android-app/src/test/kotlin/com/eygraber/portal/samples/simpleportal/android/SimplePortalAndroidTest.kt
@@ -133,13 +133,12 @@ class SimplePortalAndroidTest {
         .assertDoesNotExist()
     }
 
-    // TODO: https://github.com/eygraber/portal/issues/614
-    // rule
-    //   .onNodeWithText("2")
-    //   .assertExists()
-    //   .assertIsNotDisplayed()
-    //   .assertLeftPositionInRootIsEqualTo(2.dp)
-    //   .assertTopPositionInRootIsEqualTo((-15).dp)
+    rule
+      .onNodeWithText("2")
+      .assertExists()
+      .assertIsNotDisplayed()
+      .assertLeftPositionInRootIsEqualTo((-154).dp)
+      .assertTopPositionInRootIsEqualTo((-244).dp)
 
     rule
       .onNodeWithText("1")

--- a/samples/simple-portal/src/commonMain/kotlin/com/eygraber/portal/samples/simpleportal/SimplePortal.kt
+++ b/samples/simple-portal/src/commonMain/kotlin/com/eygraber/portal/samples/simpleportal/SimplePortal.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.shrinkOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -138,7 +139,9 @@ fun SimplePortal() {
     Surface(
       modifier = Modifier.fillMaxSize(),
     ) {
-      portalManager.Render()
+      Box {
+        portalManager.Render()
+      }
     }
   }
 }


### PR DESCRIPTION
  - In 1.6.0-beta01 AnimatedVisibility started respecting propagated min constraints
  - This causes the '2' in the simple-portal sample to not transition out correctly
  - The min constraints is coming from Surface calling Box with propagateMinConstraints set to true
  - Surface is not meant to be used as a Layout, so using a Box inside it fixes the issue
  - https://issuetracker.google.com/issues/322267501

Fixes #614 